### PR TITLE
Ignore whitespace during HTML parsing

### DIFF
--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -119,6 +119,9 @@ namespace HtmlParser
 
     void Parser::InsertionModeBeforeHtml(const Token& Token)
     {
+        if (Token.Type == TokenType::Character && isspace(Token.Data[0])) {
+            return; // Ignore whitespace
+        }
         if (Token.Type == TokenType::StartTag && Utils::ToLower(Token.Data) == "html")
         {
             InsertElement(Token);
@@ -138,6 +141,9 @@ namespace HtmlParser
 
     void Parser::InsertionModeBeforeHead(const Token& Token)
     {
+        if (Token.Type == TokenType::Character && isspace(Token.Data[0])) {
+            return; // Ignore whitespace
+        }
         if (Token.Type == TokenType::StartTag && Utils::ToLower(Token.Data) == "head")
         {
             InsertElement(Token);
@@ -157,6 +163,9 @@ namespace HtmlParser
 
     void Parser::InsertionModeInHead(const Token& Token)
     {
+        if (Token.Type == TokenType::Character && isspace(Token.Data[0])) {
+            return; // Ignore whitespace
+        }
         if (Token.Type == TokenType::EndTag && Utils::ToLower(Token.Data) == "head")
         {
             OpenElements.pop_back();
@@ -173,6 +182,9 @@ namespace HtmlParser
 
     void Parser::InsertionModeAfterHead(const Token& Token)
     {
+        if (Token.Type == TokenType::Character && isspace(Token.Data[0])) {
+            return; // Ignore whitespace
+        }
         if (Token.Type == TokenType::StartTag && Utils::ToLower(Token.Data) == "body")
         {
             InsertElement(Token);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(RunTests ParserTest.cpp DOMTest.cpp DOMStrictTest.cpp QueryTest.cpp DOMToHtmlTest.cpp QueryAdvancedTest.cpp)
+add_executable(RunTests ParserTest.cpp DOMTest.cpp DOMStrictTest.cpp QueryTest.cpp DOMToHtmlTest.cpp QueryAdvancedTest.cpp WhitespaceTest.cpp)
 target_link_libraries(RunTests HtmlParser gtest gtest_main)
 
 add_test(NAME ParserTest COMMAND RunTests)

--- a/tests/WhitespaceTest.cpp
+++ b/tests/WhitespaceTest.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <HtmlParser/Parser.hpp>
+#include <HtmlParser/DOM.hpp>
+
+TEST(ParserWhitespaceTest, WhitespaceBeforeHtml)
+{
+    HtmlParser::Parser Parser;
+    HtmlParser::DOM DOM = Parser.Parse("    \n\t  <html><body></body></html>");
+    auto Body = DOM.GetElementsByTagName("body");
+    ASSERT_EQ(Body.size(), 1);
+}
+
+TEST(ParserWhitespaceTest, WhitespaceBeforeHead)
+{
+    HtmlParser::Parser Parser;
+    HtmlParser::DOM DOM = Parser.Parse("<html>  \n\t <head></head><body></body></html>");
+    auto Head = DOM.GetElementsByTagName("head");
+    ASSERT_EQ(Head.size(), 1);
+}
+
+TEST(ParserWhitespaceTest, WhitespaceInHead)
+{
+    HtmlParser::Parser Parser;
+    HtmlParser::DOM DOM = Parser.Parse("<html><head>  \n\t </head><body></body></html>");
+    auto Head = DOM.GetElementsByTagName("head");
+    ASSERT_EQ(Head.size(), 1);
+}
+
+TEST(ParserWhitespaceTest, WhitespaceAfterHead)
+{
+    HtmlParser::Parser Parser;
+    HtmlParser::DOM DOM = Parser.Parse("<html><head></head>  \n\t <body></body></html>");
+    auto Body = DOM.GetElementsByTagName("body");
+    ASSERT_EQ(Body.size(), 1);
+}
+


### PR DESCRIPTION
Hello, Thanks for creating this beautiful parser, one of the only ones in modern C++!

I discovered a bug in the parser's state machine that causes it to generate a malformed DOM tree when parsing common, well-formatted HTML documents that contain whitespace (like newlines) between major tags such as \<html\>, \<head\>, and \<body\>.

The root cause is that when the parser is in a state like BeforeHead, it interprets a whitespace token as an implicit signal to create and immediately close the <head> tag, leading to subsequent tags like the actual <head> being inserted incorrectly into the <body>.

This pull request fixes the issue by explicitly ignoring whitespace tokens in the relevant states (BeforeHtml, BeforeHead, InHead, and AfterHead), making the parser more resilient to standard document formatting.

## How To Reproduce
Remove my changes from src/Parser.cpp and run the newly added tests

## Commit Message
The HTML parser now correctly ignores leading whitespace before the <html> and <head> tags, as well as whitespace within and after the <head> section. This improves parsing robustness for common HTML formatting variations.

- Add a new test suite (WhitespaceTest.cpp) with specific unit tests to verify this behavior.
- Update the CMake configuration to include the new test file in the build.